### PR TITLE
Replace MBString and make adaptation easier.

### DIFF
--- a/abfall.php
+++ b/abfall.php
@@ -17,6 +17,7 @@ const ABFALL_IO_KEY = "e2b5b0f129dde22e1993abc2aa4654f8";
 $io['f_id_kommune']            = '2785';
 $io['f_id_bezirk']             = '2331';
 $io['f_id_strasse']            = '2332';
+//$io['f_id_strasse_hnr']        = '0';
 $io['f_id_abfalltyp_0']        = '20';
 $io['f_id_abfalltyp_3']        = '279';
 $io['f_id_abfalltyp_4']        = '19';
@@ -64,7 +65,7 @@ foreach ($io as $key => $entry) {
 }
 
 $request = implode('&', $params);
-$url     = 'https://api.abfall.io/?key=e2b5b0f129dde22e1993abc2aa4654f8&modus=d6c5855a62cf32a4dadbc2831f0f295f&waction=export_ics';
+$url     = 'https://api.abfall.io/?key='.ABFALL_IO_KEY.'&modus=d6c5855a62cf32a4dadbc2831f0f295f&waction=export_ics';
 $res     = ServiceRequest($url, $request);
 #echo $res;
 file_put_contents('abfall.ics', $res);

--- a/abfall.php
+++ b/abfall.php
@@ -120,7 +120,7 @@ function GetDocument($url, $request)
         $dom = new DOMDocument();
         // disable libxml errors
         libxml_use_internal_errors(true);
-        $dom->loadHTML(mb_convert_encoding($response, 'HTML-ENTITIES', 'UTF-8'));
+        $dom->loadHTML(htmlspecialchars_decode(htmlentities($response, ENT_NOQUOTES), ENT_NOQUOTES));
         // remove errors for yucky html
         libxml_clear_errors();
         $xpath = new DOMXpath($dom);


### PR DESCRIPTION
Using MBString in this context is deprecated in PHP 8.2. See [php.net](https://www.php.net/manual/en/migration82.deprecated.php) and [php.watch](https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated). This also removes the need for the mbstring extension.
`f_id_strasse_hnr` is needed for some locations.